### PR TITLE
Fix: Resolve overlapping buttons in settings menu

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,7 +37,7 @@
                     <td>{{ entry['arrival_time_last_fox'] }}</td>
                     <td>
                         <a href="{{ url_for('edit_entry', entry_id=entry.id) }}" class="button-link-edit">Bewerk</a> |
-                        <form method="POST" action="{{ url_for('delete_entry', entry_id=entry.id) }}" style="display:inline;" onsubmit="return confirm('Weet je zeker dat je deze rit wilt verwijderen?');">
+                        <form method="POST" action="{{ url_for('delete_entry', entry_id=entry.id) }}" onsubmit="return confirm('Weet je zeker dat je deze rit wilt verwijderen?');">
                             <input type="submit" value="Verwijder" class="button-link-delete">
                         </form>
                     </td>


### PR DESCRIPTION
The 'Bewerk' (Edit) link and 'Verwijder' (Delete) button in the ritten (entries) table on the settings page were overlapping.

This was caused by an inline style `display:inline;` on the form containing the delete button, which forced it onto the same line as the edit link.

The fix involves removing this inline style from the form tag in `templates/settings.html`. This allows the form (which is a block-level element by default) to naturally flow to the next line, resolving the visual overlap. The functionality of both buttons remains unchanged.