### PR TITLE
Style: Place settings menu buttons inline and ensure delete is a link

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -121,14 +121,20 @@ a:hover {
 }
 
 .button-link-delete {
-    background: none!important;
-    border: none;
-    padding: 0!important;
-    color: #dc3545; /* Bootstrap's danger color, or any red */
+    background-color: transparent !important; /* Explicitly transparent */
+    background: none !important; /* Keep this for good measure */
+    border: none !important; /* Ensure no border */
+    padding: 0 !important;
+    margin: 0; /* Remove any default margins */
+    color: #dc3545; /* Red color */
     text-decoration: underline;
     cursor: pointer;
-    font-size: inherit; /* Inherit font size from table cell */
-    font-family: inherit; /* Inherit font family */
+    font-size: inherit;
+    font-family: inherit;
+    vertical-align: baseline; /* Align with surrounding text/links */
+    appearance: none; /* Attempt to disable native browser styling */
+    -webkit-appearance: none; /* For Safari/Chrome */
+    -moz-appearance: none; /* For Firefox */
 }
 
 .button-link-delete:hover {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,7 +37,7 @@
                     <td>{{ entry['arrival_time_last_fox'] }}</td>
                     <td>
                         <a href="{{ url_for('edit_entry', entry_id=entry.id) }}" class="button-link-edit">Bewerk</a> |
-                        <form method="POST" action="{{ url_for('delete_entry', entry_id=entry.id) }}" onsubmit="return confirm('Weet je zeker dat je deze rit wilt verwijderen?');">
+                        <form method="POST" action="{{ url_for('delete_entry', entry_id=entry.id) }}" style="display:inline;" onsubmit="return confirm('Weet je zeker dat je deze rit wilt verwijderen?');">
                             <input type="submit" value="Verwijder" class="button-link-delete">
                         </form>
                     </td>


### PR DESCRIPTION
Per your feedback, this change adjusts the styling of the 'Bewerk' (Edit) and 'Verwijder' (Delete) actions in the settings page table.

Modifications:
- Re-added `style="display:inline;"` to the delete action's form in `templates/settings.html` to position it on the same line as the edit link.
- Enhanced the `.button-link-delete` CSS class in `static/style.css` to more aggressively override default `input[type="submit"]` styles. This ensures the delete button renders as a simple red, underlined link, without any border, background, or padding that would give it a "boxed" appearance. Added `vertical-align: baseline;` and `appearance: none;` for better rendering and alignment.

The expected result is that the Edit link and Delete "link" (button) now appear side-by-side, with the Delete action styled as a red link, matching your requirement.