### PR TITLE
Fix: Separate edit and delete actions in settings table

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,6 +23,7 @@
                     <th>Eind KM</th>
                     <th>Aankomsttijd</th>
                     <th>Acties</th> <!-- Uncommented and added -->
+                    <th>Verwijderen</th>
                 </tr>
             </thead>
             <tbody>
@@ -36,7 +37,9 @@
                     <td>{{ entry['end_km']|int }}</td>
                     <td>{{ entry['arrival_time_last_fox'] }}</td>
                     <td>
-                        <a href="{{ url_for('edit_entry', entry_id=entry.id) }}" class="button-link-edit">Bewerk</a> |
+                        <a href="{{ url_for('edit_entry', entry_id=entry.id) }}" class="button-link-edit">Bewerk</a>
+                    </td>
+                    <td>
                         <form method="POST" action="{{ url_for('delete_entry', entry_id=entry.id) }}" style="display:inline;" onsubmit="return confirm('Weet je zeker dat je deze rit wilt verwijderen?');">
                             <input type="submit" value="Verwijder" class="button-link-delete">
                         </form>


### PR DESCRIPTION
The 'Bewerk' (Edit) and 'Verwijder' (Delete) actions in the settings table were previously in the same column, causing them to overlap.

This commit modifies `templates/settings.html` to place these actions into two separate table columns. A new table header 'Verwijderen' has been added for the delete action column. Each action now resides in its own `<td>` element, improving the layout and user experience.

The functionality of both edit and delete actions has been manually tested and confirmed to be working as expected.