### PR TITLE
feat: Add km and min units to results display

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -38,8 +38,8 @@
                 <tr class="{% if entry.rank == 1 %}rank-gold{% elif entry.rank == 2 %}rank-silver{% elif entry.rank == 3 %}rank-bronze{% endif %}">
                     <td>{{ entry['rank'] }}</td> <!-- New First Cell for Rank -->
                     <td>{{ entry.name }}</td>
-                    <td>{{ entry['calculated_km']|int }}</td>
-                    <td>{{ entry['duration_minutes'] if entry['duration_minutes'] is not none else 'N/A' }}</td>
+                    <td>{{ entry['calculated_km']|int }} km</td>
+                    <td>{{ entry['duration_minutes'] if entry['duration_minutes'] is not none else 'N/A' }}{% if entry['duration_minutes'] is not none %} min{% endif %}</td>
                     <td>{{ entry['start_km']|int }}</td>
                     <td>{{ entry['end_km']|int }}</td>
                     <td>{{ entry.arrival_time_last_fox }}</td>


### PR DESCRIPTION
Appends "km" to the driven kilometers and "min" to the duration in minutes on the results page for clarity.

The units are added directly in the `templates/results.html` template.
- "km" is added to each entry's calculated kilometers.
- "min" is added to each entry's duration, only if a duration is present (not 'N/A'). The total kilometers displayed already had "km" and remains unchanged.