### PR TITLE
feat: Add initial admin user creation via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ The application can be configured using environment variables.
           - VREETVOS_ADMIN_PASSWORD=your_secure_admin_password
     ```
 
+## Initial Admin User Setup
+
+If no admin user exists in the database when the application starts for the first time (or after the database is initialized), it can automatically create an initial admin user using the following environment variables:
+
+-   `INITIAL_ADMIN_USERNAME`: Set this to the desired username for the initial admin.
+-   `INITIAL_ADMIN_PASSWORD`: Set this to the desired password for the initial admin.
+
+Set these environment variables before running the application for the first time (e.g., in your `.env` file for Docker Compose, or directly in your environment for local execution).
+
+The application will print messages to the console (or logs) indicating the status of this process:
+- If an admin user already exists.
+- If the admin user is created successfully.
+- If the environment variables are not set and no admin user exists.
+
+It's recommended to unset or secure these variables after the first successful startup and admin user creation, especially in production environments. If these variables are not set and no admin exists, you will need to create an admin user manually via the `/admin/users/add` page after logging in with another admin/moderator, or by other means if no users exist at all.
+
 ## Setup and Running
 
 1.  **Prerequisites:**


### PR DESCRIPTION
This commit introduces a mechanism to create an initial admin user automatically when the application starts, based on specified environment variables. This simplifies the first-time setup of the application.

Key changes:

1.  **Startup Logic (`app.py`):**
    *   A new function `create_initial_admin_user()` has been added.
    *   On application startup, this function checks if an admin user already exists in the database.
    *   If no admin user is found, it attempts to read the `INITIAL_ADMIN_USERNAME` and `INITIAL_ADMIN_PASSWORD` environment variables.
    *   If both variables are set, a new admin user is created with the provided username, the password (after hashing), and the 'admin' role.
    *   Appropriate messages are printed to the console indicating success, failure, or if an admin already exists.
    *   This function is called within the application context during the app's initialization phase.

2.  **Testing (`tests/test_app.py`):**
    *   New tests have been added to verify the `create_initial_admin_user()` functionality:
        *   Successful creation when no admin exists and environment variables are set.
        *   No creation if an admin user already exists.
        *   No creation if the required environment variables are not set.
    *   These tests utilize `unittest.mock.patch` to manage environment variables for different test scenarios.

3.  **Documentation (`README.md`):**
    *   The `README.md` file has been updated with a new section explaining how to use the `INITIAL_ADMIN_USERNAME` and `INITIAL_ADMIN_PASSWORD` environment variables for setting up the first admin user.